### PR TITLE
Update with deprecation warning for CSE

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # adyen-encrypt
 
+> **[DEPRECATED]** This module is deprecated since the original Adyen CSE project is deprecated and this encrytion method will not work with latest versions of Adyen SDK. Please use the official [Adyen Web Components](https://github.com/Adyen/adyen-web) for Credit Card integration.
+
 > A rewrite of [Adyen-CSE](https://github.com/Adyen/CSE-JS) in ES2015 for the browser
 
     npm i -S adyen-encrypt


### PR DESCRIPTION
@balthazar @yangshun First of all thank you from the Adyen team for building and maintaining this lib. We appreciate it.

CSE support has been deprecated from the beginning of 2019 and we would appreciate it if you can update the readme and archive this project.